### PR TITLE
workaround for bug with Storm's LocalCluster not getting cleaned up prop...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,14 +164,89 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.12.3</version>
         <configuration>
+          <skip>true</skip>
           <systemPropertyVariables>
             <file.encoding>UTF-8</file.encoding>
             <user.timezone>GMT</user.timezone>
           </systemPropertyVariables>
-          <includes>
-            <include>**/*Test.java</include>
-          </includes>
         </configuration>
+        <!-- 
+            Due to a bug with Storm's LocalCluster not getting cleaned up properly 
+            we need to have each test execute in its own JVM, otherwise prior 
+            results come back to mess up the tests which work fine when run individually.
+
+            Please see the comment in StormEsperTest.java
+        -->
+        <executions>
+          <execution>
+            <id>group1</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <skip>false</skip>
+              <groups>1</groups>
+            </configuration>
+          </execution>
+          <execution>
+            <id>group2</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <skip>false</skip>
+              <groups>2</groups>
+            </configuration>
+          </execution>
+          <execution>
+            <id>group3</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <skip>false</skip>
+              <groups>3</groups>
+            </configuration>
+          </execution>
+          <execution>
+            <id>group4</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <skip>false</skip>
+              <groups>4</groups>
+            </configuration>
+          </execution>
+          <execution>
+            <id>group5</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <skip>false</skip>
+              <groups>5</groups>
+            </configuration>
+          </execution>
+          <execution>
+            <id>group6</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <skip>false</skip>
+              <groups>6</groups>
+            </configuration>
+          </execution>
+        </executions>
+ 
+
       </plugin>
       <plugin> 
         <groupId>org.apache.maven.plugins</groupId> 

--- a/src/test/java/org/tomdz/storm/esper/StormEsperTest.java
+++ b/src/test/java/org/tomdz/storm/esper/StormEsperTest.java
@@ -21,6 +21,13 @@ import static com.jayway.awaitility.Awaitility.await;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 
+/**
+ * Due to bug with Storm's LocalCluster not getting cleaned up properly we have to run each of the test
+ * methods in this class within a different JVM ( see: https://github.com/nathanmarz/storm/issues/201
+ * for more info.)   Every new test that is added should get a unique group number 'G', and a corresponding
+ * <execution> <groups>G</groups> ... </execution>  entry needs to be put into the surefire configuration
+ * in the  pom.xml,
+ */
 @Test
 public class StormEsperTest
 {
@@ -98,6 +105,7 @@ public class StormEsperTest
         assertEquals(actual, expected);
     }
 
+    @Test(groups = "1")
     @SuppressWarnings("unchecked")
     public void testSimple() throws Exception
     {
@@ -116,6 +124,7 @@ public class StormEsperTest
                 new Event("bolt1A", "default", null, 4, 10));
     }
 
+    @Test(groups = "2")
     @SuppressWarnings("unchecked")
     public void testMultipleStatements() throws Exception
     {
@@ -138,6 +147,7 @@ public class StormEsperTest
                 new Event("bolt2A", "stream2", "MinValue", 1));
     }
 
+    @Test(groups = "3")
     @SuppressWarnings("unchecked")
     public void testMultipleSpouts() throws Exception
     {
@@ -160,6 +170,7 @@ public class StormEsperTest
                 new Event("bolt3A", "default", null, 1, 4));
     }
 
+    @Test(groups = "4")
     @SuppressWarnings("unchecked")
     public void testNoInputAlias() throws Exception
     {
@@ -177,6 +188,7 @@ public class StormEsperTest
                 new Event("bolt4A", "default", null, 1, 4));
     }
 
+    @Test(groups = "5")
     @SuppressWarnings("unchecked")
     public void testMultipleSpoutsWithoutInputAlias() throws Exception
     {
@@ -198,6 +210,7 @@ public class StormEsperTest
                 new Event("bolt5A", "default", null, 1, 4));
     }
 
+    @Test(groups = "6")
     @SuppressWarnings("unchecked")
     public void testMultipleBolts() throws Exception
     {


### PR DESCRIPTION
Tom -  Thanks for your excellent work on this library. We are going to use it on our current project. We want to write more tests to verify our changes, but as you know the Storm issue prevents the build from passing.  This change set  works around that issue by executing each of the  test methods in this main test class within a different JVM. 

This isn't ideal since the tests take longer and you only get a report of the last test run, but at least the build will only fail if something is really wrong now.  Hope you find the change to be useful.
- chris
